### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-gui-app.yml
+++ b/.github/workflows/test-gui-app.yml
@@ -2,6 +2,9 @@ name: Windows GUI Test
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   test-gui:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Redfourk/FileLauncher/security/code-scanning/1](https://github.com/Redfourk/FileLauncher/security/code-scanning/1)

In general, the fix is to add an explicit `permissions:` block that grants only the minimal required scopes for `GITHUB_TOKEN`. For a workflow that only checks out code and runs tests, `contents: read` is typically sufficient. This can be defined at the top level of the workflow (applies to all jobs) or inside the specific job.

The best change here is to add a root-level `permissions:` block with `contents: read` just below the `on:` declaration. This documents that the workflow only needs read access to repository contents and ensures the token is not granted unnecessary write powers, regardless of repo/org defaults. No imports or other definitions are needed; this is a purely declarative YAML change within `.github/workflows/test-gui-app.yml`. Existing steps (`actions/checkout@v4`, Python setup, dependency installation, and test run) will continue to work with read-only contents access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
